### PR TITLE
removed grizzly from tapis-shared-api pom

### DIFF
--- a/tapis-shared-api/pom.xml
+++ b/tapis-shared-api/pom.xml
@@ -126,10 +126,6 @@
 			<groupId>org.glassfish.jersey.test-framework</groupId>
 			<artifactId>jersey-test-framework-core</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.glassfish.jersey.test-framework.providers</groupId>
-			<artifactId>jersey-test-framework-provider-grizzly2</artifactId>
-		</dependency>
 	</dependencies>
     
     <build>


### PR DESCRIPTION
will need to be done in conjunction with the pull requests for branch withGrizz in tapis-files and tapis-systems