### PR TITLE
Dvernon/ssh session pool enhancement

### DIFF
--- a/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/SshSessionHolder.java
+++ b/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/SshSessionHolder.java
@@ -1,0 +1,52 @@
+package edu.utexas.tacc.tapis.shared.ssh;
+
+import edu.utexas.tacc.tapis.shared.ssh.apache.SSHConnection;
+import edu.utexas.tacc.tapis.shared.ssh.apache.SSHSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The name of this class is "SshSessionHolder" because it holds the class called SSHSession.  It's used to
+ * hold the spot for an SshSession in the SshSessionPool (specifically in the connection context).  This allows
+ * the session context to return a place holder to the pool so that actually establishing the connection can
+ * be done outside of any synchronized block of code.
+ * @param <T>
+ */
+class SshSessionHolder <T extends SSHSession> {
+    private static Logger log = LoggerFactory.getLogger(SshSessionHolder.class);
+    private final SshConnectionContext sshConnectionContext;
+    private final SSHConnection sshConnection;
+    private final SshConnectionContext.SessionConstructor<T> sessionConstructor;
+    private final long threadId;
+    private T session = null;
+
+    public SshSessionHolder(SshConnectionContext sshConnectionContext, SSHConnection sshConnection, SshConnectionContext.SessionConstructor<T> sessionConstructor) {
+        this.sshConnectionContext = sshConnectionContext;
+        this.sshConnection = sshConnection;
+        this.sessionConstructor = sessionConstructor;
+        this.threadId = Thread.currentThread().getId();
+    }
+
+    public boolean containsSession() {
+        return session != null;
+    }
+
+    public T getSession() {
+        return session;
+    }
+
+    public T createSession() throws Exception {
+        session = this.sessionConstructor.constructSession(this.sshConnection);
+        return session;
+    }
+
+    public long getThreadId() {
+        return threadId;
+    }
+
+    public void expireConnection() {
+        if(session != null) {
+            this.sshConnectionContext.expireConnection();
+        }
+    }
+}


### PR DESCRIPTION
There are several changes in this commit to address some issues in files.  There are no changes to the interface so nothing needs to change in code using this library.

The first (and main one) is to the SshSessionPool code.  It will only affect users of the SshSessionPool (currently just files).  I added the SshSessionHolder class.  This is used by SshConnectionContext (the class that manages sessions on a connection).  When the SshConnectionGroup (class that keeps a list of all SshConnectionContexts for a given pool key - aka machine/user combo) reserves a session from an SshConnectionContext it no longer receives a connected session.  It now receives a connection holder allowing the SshConnectionGroup to release it's lock on the ConnectionContext list.  The SshSessionHolder allows the SshSessionGroup to create the session outside the lock minimizing the time the lock is held.  There are a number of changes required to accommodate that.

This change also cleans up the pool logging.  You can easily see stats at the info level, and if you move it to debug or trace you can get more.  Trace is VERY verbose, but super helpful in diagnosing issues.  Files re-reads the logback.xml so it can be altered at anytime.

SSHSftpClient - fixed the case where we try to close a session, but don't wait for it to actually close.  There is no good way to do this with the mina client, but there is enough info for us to poll/wait for close.  That is essential for the ssh session pool to do it's job.

SSHExecChannel - fixed a bug where we were writing the command we execute to stdin of the command we execute.  For example, if you execute "myCommand" we would write (via a pipe) "myCommand" to stdin for the newly executed myCommand.