### PR TITLE
Enhancement to the way we release ssh sessions that improves concurrency

### DIFF
--- a/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/apache/SshConnectionListener.java
+++ b/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/apache/SshConnectionListener.java
@@ -1,0 +1,5 @@
+package edu.utexas.tacc.tapis.shared.ssh.apache;
+
+public interface SshConnectionListener {
+    public void onRelease(boolean succeeded);
+}


### PR DESCRIPTION
This is addressing some of the comments from this pr - https://github.com/tapis-project/tapis-shared-java/pull/36
Previously we were searching session groups/contexts for the specific session to release.  Now we will just store away the context that the session is in, and use that to close/release the session.