### PR TITLE
Dvernon/ssh pool park sessions

### DIFF
--- a/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/SshConnectionContext.java
+++ b/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/SshConnectionContext.java
@@ -186,7 +186,8 @@ final class SshConnectionContext {
                 result = activeSshSessionHolders.remove(sessionHolder);
             }
         } else {
-            log.error("WARN SessionHolder Null!!!");
+            String msg = MsgUtils.getMsg("SSH_POOL_NULL_VARIABLE", "sessionHolder");
+            log.error(msg);
         }
         this.idleSinceTime = System.currentTimeMillis();
         return result;
@@ -218,13 +219,18 @@ final class SshConnectionContext {
 
     protected synchronized void close() {
         // Close the SshConnection associated with this context.
-        log.trace("Cleanup parked sessions");
+
+
+
+        String msg = MsgUtils.getMsg("SSH_POOL_TRACE_CLEANUP_PARKED");
+        log.trace(msg);
         Iterator<SshSessionHolder<SSHSftpClient>> parkedSessionIterator = parkedSftpSessionHolders.iterator();
         while(parkedSessionIterator.hasNext()) {
             parkedSessionIterator.next();
             parkedSessionIterator.remove();
         }
-        log.trace("Closing SSH connection");
+        msg = MsgUtils.getMsg("SSH_POOL_TRACE_CLOSE_CONNECTION");
+        log.trace(msg);
         sshConnection.close();
     }
 

--- a/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/SshConnectionContext.java
+++ b/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/SshConnectionContext.java
@@ -11,8 +11,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 
 /**
@@ -35,9 +35,12 @@ final class SshConnectionContext {
     // if there are no sessions (the elapsed time in milliseconds since the last session was closed).
     private long idleSinceTime;
     //  SessionHolder is a class that reserves a spot for a session.  The session will get connected later.
-    private final Set<SshSessionHolder> sessionHolders;
+    private final Set<SshSessionHolder<SSHExecChannel>> activeSshSessionHolders;
+    private final Set<SshSessionHolder<SSHSftpClient>> activeSftpSessionHolders;
+    private final Set<SshSessionHolder<SSHSftpClient>> parkedSftpSessionHolders;
     private final long lifetimeMs;
     private final long maxIdleTimeMs;
+    private final long maxSessionLifetime;
 
     /**
      * ExecChannelConstructor can be used to construct an SSHExecChannel when calling reserveSession
@@ -49,23 +52,27 @@ final class SshConnectionContext {
      */
     protected static SessionConstructor<SSHSftpClient> SftpClientConstructor = SshConnectionContext::constructSftpClient;
 
-    protected SshConnectionContext(SSHConnection sshConnection, int maxSessions, Duration connectionDuration,
-                                Duration maxConnectionIdleTime) {
+    protected SshConnectionContext(SSHConnection sshConnection, SshSessionPoolPolicy poolPolicy) {
         this.sshConnection = sshConnection;
-        this.maxSessions = maxSessions;
+        this.maxSessions = poolPolicy.getMaxSessionsPerConnection();
         this.creationTime = System.currentTimeMillis();
-        this.lifetimeMs = connectionDuration.toMillis();
-        this.maxIdleTimeMs = maxConnectionIdleTime.toMillis();
+        this.lifetimeMs = poolPolicy.getMaxConnectionDuration().toMillis();
+        this.maxIdleTimeMs = poolPolicy.getMaxConnectionIdleTime().toMillis();
+        this.maxSessionLifetime = poolPolicy.getMaxSessionLifetime().toMillis();
         this.idleSinceTime = System.currentTimeMillis();
         this.expired = false;
-        sessionHolders = new HashSet<>();
+        activeSshSessionHolders = new HashSet<>();
+        activeSftpSessionHolders = new HashSet<>();
+        parkedSftpSessionHolders = new HashSet<>();
+
+
+
+
     }
 
-    protected int getSessionCount() {
+    protected synchronized int getSessionCount() {
         // include all session holders in the count - even the ones with sessions that are not yet created.
-        synchronized (sessionHolders) {
-            return sessionHolders.size();
-        }
+        return (activeSshSessionHolders.size() + activeSftpSessionHolders.size());
     }
 
 
@@ -100,24 +107,56 @@ final class SshConnectionContext {
             return false;
         }
 
-        return sessionHolders.size() < maxSessions;
+        return (activeSshSessionHolders.size() + activeSftpSessionHolders.size()) < maxSessions;
     }
 
-    protected <T extends SSHSession> SshSessionHolder<T> reserveSession(SessionConstructor<T> sessionConstructor) throws TapisException {
-        synchronized(sessionHolders) {
-            if (hasAvailableSessions()) {
-                SshSessionHolder<T> sessionHolder = null;
+    protected synchronized SshSessionHolder<SSHSftpClient> reserveSftpSession() throws TapisException {
+        if (hasAvailableSessions()) {
+            SshSessionHolder<SSHSftpClient> sessionHolder = null;
+            Iterator<SshSessionHolder<SSHSftpClient>> parkedSessionHolderIterator = parkedSftpSessionHolders.iterator();
+            while (parkedSessionHolderIterator.hasNext()) {
+                SshSessionHolder<SSHSftpClient> parkedSftpSessionHolder = parkedSessionHolderIterator.next();
+                parkedSessionHolderIterator.remove();
+                if ((!sessionIsExpired(parkedSftpSessionHolder)) && (parkedSftpSessionHolder.getSession().isOpen())) {
+                    sessionHolder = parkedSftpSessionHolder;
+                    break;
+                } else {
+                    IOUtils.closeQuietly(sessionHolder);
+                }
+            }
+
+            if (sessionHolder == null) {
                 try {
-                    sessionHolder = new SshSessionHolder<T>(this, this.sshConnection, sessionConstructor);
+                    sessionHolder = new SshSessionHolder<SSHSftpClient>(this, this.sshConnection, SshConnectionContext.SftpClientConstructor);
                 } catch (Exception ex) {
                     // if we are unable to create new sessions on this connection, we will expire it
                     this.expireConnection();
                     String msg = MsgUtils.getMsg("SSH_POOL_UNABLE_TO_CREATE_CHANNEL");
                     throw new TapisException(msg, ex);
                 }
-                sessionHolders.add(sessionHolder);
-                return sessionHolder;
             }
+            activeSftpSessionHolders.add(sessionHolder);
+            return sessionHolder;
+        }
+
+        return null;
+    }
+
+    protected SshSessionHolder<SSHExecChannel> reserveSshSession() throws TapisException {
+        if (hasAvailableSessions()) {
+            SshSessionHolder<SSHExecChannel> sessionHolder = null;
+            if (sessionHolder == null) {
+                try {
+                    sessionHolder = new SshSessionHolder<SSHExecChannel>(this, this.sshConnection, SshConnectionContext.ExecChannelConstructor);
+                } catch (Exception ex) {
+                    // if we are unable to create new sessions on this connection, we will expire it
+                    this.expireConnection();
+                    String msg = MsgUtils.getMsg("SSH_POOL_UNABLE_TO_CREATE_CHANNEL");
+                    throw new TapisException(msg, ex);
+                }
+            }
+            activeSshSessionHolders.add(sessionHolder);
+            return sessionHolder;
         }
 
         return null;
@@ -130,18 +169,21 @@ final class SshConnectionContext {
      * @param sessionHolder SessionHolder to release.
      * @return true for success, or false for failure.
      */
-    protected boolean releaseSessionHolder(SshSessionHolder sessionHolder) {
+    protected synchronized boolean releaseSessionHolder(SshSessionHolder sessionHolder) {
         boolean result = false;
-        if(sessionHolder != null) {
-            synchronized(sessionHolders) {
-                SSHSession session = sessionHolder.getSession();
-                if (session instanceof SSHSftpClient client) {
-                    if (client.isOpen()) {
-                        log.warn("Found open SftpClient session.");
-                        IOUtils.closeQuietly(client);
+        if (sessionHolder != null) {
+            SSHSession session = sessionHolder.getSession();
+            if (session instanceof SSHSftpClient client) {
+                if (client.isOpen()) {
+                    result = activeSftpSessionHolders.remove(sessionHolder);
+                    if(sessionIsExpired(sessionHolder)) {
+                        IOUtils.closeQuietly(sessionHolder);
+                    } else {
+                        parkedSftpSessionHolders.add(sessionHolder);
                     }
                 }
-                result = sessionHolders.remove(sessionHolder);
+            } else {
+                result = activeSshSessionHolders.remove(sessionHolder);
             }
         } else {
             log.error("WARN SessionHolder Null!!!");
@@ -150,13 +192,17 @@ final class SshConnectionContext {
         return result;
     }
 
-    protected long getIdleTime() {
+    protected synchronized long getIdleTime() {
         // if there is at least one session, just return 0 meaning it's not idle
-        synchronized(sessionHolders) {
-            for (SshSessionHolder sessionHolder : sessionHolders) {
-                if (sessionHolder.getSession() != null) {
-                    return 0;
-                }
+        for (SshSessionHolder<SSHSftpClient> sessionHolder : activeSftpSessionHolders) {
+            if (sessionHolder.getSession() != null) {
+                return 0;
+            }
+        }
+
+        for (SshSessionHolder<SSHExecChannel> sessionHolder : activeSshSessionHolders) {
+            if (sessionHolder.getSession() != null) {
+                return 0;
             }
         }
 
@@ -184,16 +230,19 @@ final class SshConnectionContext {
         return sshConnection.getSftpClient();
     }
 
-    protected boolean hasSessionsForThreadId(long threadId) {
-        synchronized(sessionHolders) {
-            for (SshSessionHolder sessionHolder : sessionHolders) {
-                if ((sessionHolder != null) && (threadId == sessionHolder.getThreadId())) {
-                    return true;
-                }
+    private <T extends SSHSession> boolean sessionIsExpired(SshSessionHolder<T> sessionHolder) {
+        return sessionHolder.getSessionDuration() > maxSessionLifetime;
+    }
+
+    protected synchronized void cleanup() {
+        Iterator<SshSessionHolder<SSHSftpClient>> sessionHolderIterator = parkedSftpSessionHolders.iterator();
+        while (sessionHolderIterator.hasNext()) {
+            SshSessionHolder<SSHSftpClient> sessionHolder = sessionHolderIterator.next();
+            if(sessionIsExpired(sessionHolder)) {
+                sessionHolderIterator.remove();
+                IOUtils.closeQuietly(sessionHolder);
             }
         }
-
-        return false;
     }
 
     @Override
@@ -207,9 +256,11 @@ final class SshConnectionContext {
         builder.append(", ");
         builder.append(isExpired() ? "EXPIRED" : "ACTIVE");
         builder.append(", ");
-        builder.append("Sessions: ");
+        builder.append("Active Sessions: ");
         builder.append(getSessionCount());
         builder.append(", ");
+        builder.append("Parked Sessions: ");
+        builder.append(parkedSftpSessionHolders.size());
         return builder.toString();
     }
 }

--- a/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/SshSessionHolder.java
+++ b/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/SshSessionHolder.java
@@ -3,7 +3,6 @@ package edu.utexas.tacc.tapis.shared.ssh;
 import edu.utexas.tacc.tapis.shared.ssh.apache.SSHConnection;
 import edu.utexas.tacc.tapis.shared.ssh.apache.SSHSession;
 import edu.utexas.tacc.tapis.shared.ssh.apache.SSHSftpClient;
-import org.apache.sshd.sftp.client.SftpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/SshSessionHolder.java
+++ b/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/SshSessionHolder.java
@@ -1,12 +1,14 @@
 package edu.utexas.tacc.tapis.shared.ssh;
 
-import edu.utexas.tacc.tapis.shared.i18n.MsgUtils;
 import edu.utexas.tacc.tapis.shared.ssh.apache.SSHConnection;
 import edu.utexas.tacc.tapis.shared.ssh.apache.SSHSession;
 import edu.utexas.tacc.tapis.shared.ssh.apache.SSHSftpClient;
-import edu.utexas.tacc.tapis.shared.ssh.apache.SshConnectionListener;
+import org.apache.sshd.sftp.client.SftpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
 
 /**
  * The name of this class is "SshSessionHolder" because it holds the class called SSHSession.  It's used to
@@ -15,25 +17,18 @@ import org.slf4j.LoggerFactory;
  * be done outside of any synchronized block of code.
  * @param <T>
  */
-class SshSessionHolder <T extends SSHSession> {
+class SshSessionHolder <T extends SSHSession> implements Closeable {
     private static Logger log = LoggerFactory.getLogger(SshSessionHolder.class);
     private final SshConnectionContext sshConnectionContext;
     private final SSHConnection sshConnection;
     private final SshConnectionContext.SessionConstructor<T> sessionConstructor;
-    private final long threadId;
     private T session = null;
-
-    private SshConnectionListener connectionListener;
+    private Long connectionTime = null;
 
     public SshSessionHolder(SshConnectionContext sshConnectionContext, SSHConnection sshConnection, SshConnectionContext.SessionConstructor<T> sessionConstructor) {
         this.sshConnectionContext = sshConnectionContext;
         this.sshConnection = sshConnection;
         this.sessionConstructor = sessionConstructor;
-        this.threadId = Thread.currentThread().getId();
-    }
-
-    public boolean containsSession() {
-        return session != null;
     }
 
     public T getSession() {
@@ -41,12 +36,25 @@ class SshSessionHolder <T extends SSHSession> {
     }
 
     public T createSession() throws Exception {
-        session = this.sessionConstructor.constructSession(this.sshConnection);
+        if(session == null) {
+            session = this.sessionConstructor.constructSession(this.sshConnection);
+            connectionTime = Long.valueOf(System.currentTimeMillis());
+        }
         return session;
     }
 
-    public long getThreadId() {
-        return threadId;
+    public void close() throws IOException {
+        if(session instanceof SSHSftpClient sftpClient) {
+            sftpClient.close();
+        }
+    }
+
+    protected long getSessionDuration() {
+        if(connectionTime == null) {
+            return 0;
+        }
+
+        return System.currentTimeMillis() - connectionTime.longValue();
     }
 
     public void expireConnection() {
@@ -55,23 +63,8 @@ class SshSessionHolder <T extends SSHSession> {
         }
     }
 
-    public void setConnectionListener(SshConnectionListener connectionListener) {
-        this.connectionListener = connectionListener;
-    }
-
     public boolean release() {
-        if (session instanceof SSHSftpClient sftpSession) {
-            try {
-                sftpSession.close();
-            } catch (Exception ex) {
-                // nothing we can really do about this, so just log it.
-                String msg = MsgUtils.getMsg("SSH_POOL_UNABLE_TO_CLOSE_SESSION", "SSHSftpClient");
-                log.warn(msg);
-            }
-        }
-
         boolean released = this.sshConnectionContext.releaseSessionHolder(this);
-        this.connectionListener.onRelease(released);
         return released;
     }
 }

--- a/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/SshSessionPool.java
+++ b/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/SshSessionPool.java
@@ -250,7 +250,7 @@ public final class SshSessionPool {
     }
 
     private void cleanup() {
-        log.info("SshSessionPool cleanup counter: " + traceOnCleanupCounter.get());
+        log.info(MsgUtils.getMsg("SSH_POOL_CLEANUP_COUNTER", traceOnCleanupCounter.get()));
         for (SshSessionPoolKey key : pool.keySet()) {
             SshConnectionGroup connectionGroup = pool.get(key);
             connectionGroup.cleanup();

--- a/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/apache/SSHSftpClient.java
+++ b/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/apache/SSHSftpClient.java
@@ -75,8 +75,10 @@ public class SSHSftpClient
             String msg =  MsgUtils.getMsg("TAPIS_SSH_NO_SESSION");
             throw new TapisRuntimeException(msg);
         }
+        long begin = System.currentTimeMillis();
         _sftpClient = (DefaultSftpClient)
             DefaultSftpClientFactory.INSTANCE.createSftpClient(session);
+        log.error("***-*** Session took this long --------------------------> " + (System.currentTimeMillis() - begin));
     }
     
     public SSHConnection getConnection() {return _sshConnection;}

--- a/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/apache/SSHSftpClient.java
+++ b/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/apache/SSHSftpClient.java
@@ -78,7 +78,7 @@ public class SSHSftpClient
         long begin = System.currentTimeMillis();
         _sftpClient = (DefaultSftpClient)
             DefaultSftpClientFactory.INSTANCE.createSftpClient(session);
-        log.error("***-*** Session took this long --------------------------> " + (System.currentTimeMillis() - begin));
+        log.trace(MsgUtils.getMsg("SSH_SFTP_TRACE_SESSION_TIME", System.currentTimeMillis() - begin));
     }
     
     public SSHConnection getConnection() {return _sshConnection;}
@@ -102,7 +102,7 @@ public class SSHSftpClient
         for(int i=0;i<10;i++) {
             if(!_sftpClient.getClientChannel().isClosed()) {
                 try {
-                    log.trace(String.format("Waiting for sftpClient to close %d", i));
+                    log.trace(String.format(MsgUtils.getMsg("SSH_SFTP_TRACE_CLOSE_WAIT", i)));
                     Thread.sleep(100);
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
@@ -117,21 +117,21 @@ public class SSHSftpClient
         if(_sftpClient.isClosing()) {
             // there's really nothing we can do here but it would be interesting to
             // know when it happens.
-            log.trace("SftpClient is in the \"isClosing\" state");
+            log.error(MsgUtils.getMsg("SSH_SFTP_TRACE_STATE", "isClosing"));
         }
 
         // this is jjust some logging that could come in handy for debugging purposes
         if(!_sftpClient.getClientChannel().isClosed()) {
             // there's really nothing we can do here but it would be interesting to
             // know when it happens.
-            log.error("SftpClient is NOT in the \"isClosed\" state");
+            log.info(MsgUtils.getMsg("SSH_SFTP_TRACE_STATE", "isClosed"));
         }
 
         // this is jjust some logging that could come in handy for debugging purposes
         if(_sftpClient.isOpen()) {
             // there's really nothing we can do here but it would be interesting to
             // know when it happens.
-            log.error("SftpClient is in the \"isOpen\" state");
+            log.error(MsgUtils.getMsg("SSH_SFTP_TRACE_STATE", "isOpen"));
         }
     }
     

--- a/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/apache/SshConnectionListener.java
+++ b/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/apache/SshConnectionListener.java
@@ -1,5 +1,0 @@
-package edu.utexas.tacc.tapis.shared.ssh.apache;
-
-public interface SshConnectionListener {
-    public void onRelease(boolean succeeded);
-}

--- a/tapis-shared-lib/src/main/resources/edu/utexas/tacc/tapis/shared/i18n/TapisMessages.properties
+++ b/tapis-shared-lib/src/main/resources/edu/utexas/tacc/tapis/shared/i18n/TapisMessages.properties
@@ -2316,6 +2316,18 @@ SSH_CREATE_NEW_SHELL_FAILURE=SSH_CREATE_NEW_SHELL_FAILURE Unable to create new s
 SSH_INTERACTIVE_SHELL_SESSION_FAILURE=SSH_INTERACTIVE_SHELL_SESSION_FAILURE Failed to establish interactive shell session to {0}:{1} {2} for {3}
     # 0 = error message
 SSH_MAVERICK_SFTP_LOG_LEVEL_FAILURE=SSH_MAVERICK_SFTP_LOG_LEVEL_FAILURE Unable to set Maverick (third party library) internal log level: {0} 
+    # 0 = time in millis
+SSH_SFTP_TRACE_SESSION_TIME=SSH_SFTP_TRACE_SESSION_TIME Sftp session established in {0} milliseconds
+    # iterations
+SSH_SFTP_TRACE_CLOSE_WAIT=SSH_SFTP_TRACE_CLOSE_WAIT Waiting for sftpClient to close {0}
+    # state
+SSH_SFTP_TRACE_STATE=SSH_SFTP_TRACE_CLOSING SftpClient is in the {0} state
+
+
+
+
+    # 0 = variable name
+SSH_POOL_NULL_VARIABLE=SSH_POOL_NULL_VARIABLE Found null value for {0}
 SSH_POOL_ALREADY_CREATED=SSH_POOL_ALREADY_CREATED SshSessionPool has already been created
     # 0 = tenant, 1 = host, 2 = port, 3 = effectiveUserId, 4 = authnMethod
 SSH_POOL_MISSING_CONNECTION_INFORMATION=SSH_POOL_MISSING_CONNECTION_INFORMATION Missing required connection information Tenant: {0}, Host: {1}, Port: {2}, EffectiveUserId: {3}, AuthnMethod: {4}
@@ -2349,9 +2361,12 @@ SSH_POOL_CONNECTION_EXPIRATION_REQUESTED=SSH_POOL_CONNECTION_EXPIRATION_REQUESTE
 SSH_POOL_CLEANUP_SKIPPED=SSH_POOL_CLEANUP_SKIPPED Unable to acquire lock on the ssh session pool in a reasonable amount of time.  Skipping cleanup this cycle.
     # no params
 SSH_POOL_CLEANUP_EXCEPTION=SSH_POOL_CLEANUP_SKIPPED Unable to complete SshSessionPool cleanup.
-
-# 0 = elapsedTime
+    # 0 = elapsedTime
 SSH_POOL_RESERVE_ELAPSED_TIME=SSH_POOL_RESERVE_ELAPSED_TIME Reserve connection elapsedTime: {0}
+SSH_POOL_TRACE_CLEANUP_PARKED=SSH_POOL_TRACE_CLEANUP_PARKED Cleaning up parked sessions
+SSH_POOL_TRACE_CLOSE_CONNECTION=SSH_POOL_TRACE_CLOSE_CONNECTION Closing ssh connection
+    # 0 counter
+SSH_POOL_CLEANUP_COUNTER=SSH_POOL_CLEANUP_COUNTER SshSessionPool cleanup counter: {0}
 
 ##########################################################################################
 # IRODS Section 


### PR DESCRIPTION
When session are returned, don't close them immediately.  They can be reused within a configurable length of time.