### PR TITLE
Adding code that will support better retries for ssh/sftp connections

### DIFF
--- a/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/ConnectionGroupStats.java
+++ b/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/ConnectionGroupStats.java
@@ -2,6 +2,7 @@ package edu.utexas.tacc.tapis.shared.ssh;
 
 public final class ConnectionGroupStats {
     private final int connectionCount;
+    private final SshConnectionGroup.Status groupStatus;
     private final int expiredConnectionCount;
     private final int activeConnectionCount;
     private final int sessionCount;
@@ -10,7 +11,8 @@ public final class ConnectionGroupStats {
     private final int sessionsOnParkedSftpConnections;
 
     protected ConnectionGroupStats(int connectionCount, int expiredConnectionCount, int activeConnectionCount, int sessionCount,
-                                   int sessionsOnExpiredConnections, int sessionsOnActiveConnections, int sessionsOnParkedSftpConnections) {
+                                   int sessionsOnExpiredConnections, int sessionsOnActiveConnections, int sessionsOnParkedSftpConnections,
+                                   SshConnectionGroup.Status groupStatus) {
         this.connectionCount = connectionCount;
         this.activeConnectionCount = activeConnectionCount;
         this.expiredConnectionCount = expiredConnectionCount;
@@ -18,6 +20,7 @@ public final class ConnectionGroupStats {
         this.sessionsOnActiveConnections = sessionsOnActiveConnections;
         this.sessionsOnExpiredConnections = sessionsOnExpiredConnections;
         this.sessionsOnParkedSftpConnections = sessionsOnParkedSftpConnections;
+        this.groupStatus = groupStatus;
     }
 
     public int getActiveConnectionCount() {
@@ -46,5 +49,9 @@ public final class ConnectionGroupStats {
 
     public int getSessionsOnParkedSftpConnections() {
         return sessionsOnParkedSftpConnections;
+    }
+
+    public String getGroupStatus() {
+        return groupStatus == null ? "null" : groupStatus.toString();
     }
 }

--- a/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/SshConnectionGroup.java
+++ b/tapis-shared-lib/src/main/java/edu/utexas/tacc/tapis/shared/ssh/SshConnectionGroup.java
@@ -2,6 +2,7 @@ package edu.utexas.tacc.tapis.shared.ssh;
 
 import edu.utexas.tacc.tapis.shared.exceptions.TapisException;
 import edu.utexas.tacc.tapis.shared.exceptions.recoverable.TapisRecoverableException;
+import edu.utexas.tacc.tapis.shared.exceptions.recoverable.TapisSSHConnectionException;
 import edu.utexas.tacc.tapis.shared.i18n.MsgUtils;
 import edu.utexas.tacc.tapis.shared.ssh.apache.SSHConnection;
 import edu.utexas.tacc.tapis.shared.ssh.apache.SSHExecChannel;
@@ -14,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,6 +23,11 @@ import java.util.List;
  * This class represents all connections and sessions for a given key in the pool.
  */
 final class SshConnectionGroup {
+    enum Status {
+        OK,
+        RECENT_CONNECTION_FAILURE
+    }
+
     private static final Logger log = LoggerFactory.getLogger(SshConnectionGroup.class);
 
     // report this group as "not ready for cleanup" for 30 mins after the last time
@@ -31,6 +38,10 @@ final class SshConnectionGroup {
     private List<SshConnectionContext> connectionContextList;
     private SshSessionPoolPolicy poolPolicy;
     private long lastTouched;
+    private Status groupStatus = Status.OK;
+    private Instant statusInstant = Instant.now();
+    private static final long CONNECTION_FAILURE_RETRY_TIMEOUT_MILLIS = 10000;
+
     protected SshConnectionGroup(SshSessionPoolPolicy poolPolicy) {
         connectionContextList = new ArrayList<>();
         this.poolPolicy = poolPolicy;
@@ -69,7 +80,8 @@ final class SshConnectionGroup {
         }
 
        return new ConnectionGroupStats(connectionCount, expiredConnectionCount, activeConnectionCount,
-                sessionCount, sessionsOnExpiredConnections, sessionsOnActiveConnections, sessionsOnParkedSftpConnections);
+                sessionCount, sessionsOnExpiredConnections, sessionsOnActiveConnections,
+               sessionsOnParkedSftpConnections, groupStatus);
     }
 
     protected void cleanup() {
@@ -227,6 +239,16 @@ final class SshConnectionGroup {
                                                 AuthnEnum authnMethod, Credential credential)
             throws TapisException
     {
+        if(groupStatus == Status.RECENT_CONNECTION_FAILURE) {
+            if(statusInstant.isBefore(Instant.now().minusMillis(CONNECTION_FAILURE_RETRY_TIMEOUT_MILLIS))) {
+                setStatus(Status.OK);
+            } else {
+                String msg = MsgUtils.getMsg("SSH_POOL_CONNECTION_FAILURE_GROUPS_STATUS",
+                        tenant, host, port, effectiveUserId, authnMethod, groupStatus);
+                log.info(msg);
+                throw new TapisSSHConnectionException(msg, null, null);
+            }
+        }
         // check connection details for non-empty values
         if((StringUtils.isBlank(host))
                 || (port == null)
@@ -275,10 +297,19 @@ final class SshConnectionGroup {
             e.state.put("port", port.toString());
             e.state.put("effectiveUserId", effectiveUserId);
             throw e;
+        } finally {
+            if(conn == null) {
+                setStatus(Status.RECENT_CONNECTION_FAILURE);
+            }
         }
 
         // Non-null if we get here.
         return conn;
+    }
+
+    private synchronized void setStatus(Status status){
+        statusInstant = Instant.now();
+        groupStatus = status;
     }
 
     @Override
@@ -290,6 +321,9 @@ final class SshConnectionGroup {
         StringBuilder builder = new StringBuilder();
 
         synchronized (connectionContextList) {
+            builder.append("Group Status: ");
+            builder.append(this.groupStatus);
+            builder.append(System.lineSeparator());
             for (SshConnectionContext connectionContext : connectionContextList) {
                 builder.append(connectionContext.getDetails(includeAll));
                 builder.append(System.lineSeparator());

--- a/tapis-shared-lib/src/main/resources/edu/utexas/tacc/tapis/shared/i18n/TapisMessages.properties
+++ b/tapis-shared-lib/src/main/resources/edu/utexas/tacc/tapis/shared/i18n/TapisMessages.properties
@@ -1102,6 +1102,8 @@ SSH_POOL_MISSING_CONNECTION_INFORMATION=SSH_POOL_MISSING_CONNECTION_INFORMATION 
 SSH_POOL_MISSING_CREDENTIALS=SSH_POOL_MISSING_CREDENTIALS Missing credentials Tenant: {0}, Host: {1}, Port: {2}, EffectiveUserId: {3}, AuthnMethod: {4}
     # 0 = tenant, 1 = host, 2 = port, 3 = effectiveUserId, 4 = authnMethod
 SSH_POOL_UNSUPPORTED_AUTHN_METHOD=SSH_POOL_UNSUPORTED_AUTHN_METHOD Unsupported authentication method. Tenant: {0}, Host: {1}, Port: {2}, EffectiveUserId: {3}, AuthnMethod: {4}
+    # 0 = tenant, 1 = host, 2 = port, 3 = effectiveUserId, 4 = authnMethod, 5 = connectionGroupStatus
+SSH_POOL_CONNECTION_FAILURE_GROUPS_STATUS=SSH_POOL_CONNECTION_FAILURE_GROUPS_STATUS SSH_POOL_CONNECTION_FAILURE Ssh/Sftp connection failed.  Tenant: {0}, Host: {1}, Port: {2}, EffectiveUserId: {3}, AuthnMethod: {4},  ConnectionGroupStatus: {5}
     # 0 = tenant, 1 = host, 2 = port, 3 = effectiveUserId, 4 = authnMethod, 5 = timeout
 SSH_POOL_RESERVE_TIMEOUT=SSH_POOL_RESERVE_TIMEOUT Unable to reserve ssh session within the timeout period. Tenant: {0}, Host: {1}, Port: {2}, EffectiveUserId: {3}, AuthnMethod: {4}, Timeout: {5}
     # 0 = tenant, 1 = host, 2 = port, 3 = effectiveUserId, 4 = authnMethod, 5 = timeout


### PR DESCRIPTION
This change will add a status to SshConnectionGroups.  The status will allow us to mark a connection group in a way that we can know a connection recently failed.  If the failure is very recent (seconds ago), we will just fail all sessions there are scheduled for this connection group - presumably they would fail again.  After a certain time passes, we will clear that status on the next session / connection attempt.  This will allow for much greater throughput in file transfers when connections are failing.